### PR TITLE
[#26] feat: 섹션 15. 상속을 이용한 BaseModel 구현

### DIFF
--- a/nestjs_server/src/app.module.ts
+++ b/nestjs_server/src/app.module.ts
@@ -7,6 +7,7 @@ import {PostsModel} from './posts/entities/posts.entity';
 import { UsersModule } from './users/users.module';
 import {UsersModel} from './users/entities/users.entity';
 import { AuthModule } from './auth/auth.module';
+import { CommonModule } from './common/common.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { AuthModule } from './auth/auth.module';
     }),
     UsersModule,
     AuthModule,
+    CommonModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/nestjs_server/src/common/common.controller.spec.ts
+++ b/nestjs_server/src/common/common.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonController } from './common.controller';
+import { CommonService } from './common.service';
+
+describe('CommonController', () => {
+  let controller: CommonController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CommonController],
+      providers: [CommonService],
+    }).compile();
+
+    controller = module.get<CommonController>(CommonController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/nestjs_server/src/common/common.controller.ts
+++ b/nestjs_server/src/common/common.controller.ts
@@ -1,0 +1,7 @@
+import { Controller } from '@nestjs/common';
+import { CommonService } from './common.service';
+
+@Controller('common')
+export class CommonController {
+  constructor(private readonly commonService: CommonService) {}
+}

--- a/nestjs_server/src/common/common.module.ts
+++ b/nestjs_server/src/common/common.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { CommonService } from './common.service';
+import { CommonController } from './common.controller';
+
+@Module({
+  controllers: [CommonController],
+  providers: [CommonService],
+})
+export class CommonModule {}

--- a/nestjs_server/src/common/common.service.spec.ts
+++ b/nestjs_server/src/common/common.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CommonService } from './common.service';
+
+describe('CommonService', () => {
+  let service: CommonService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CommonService],
+    }).compile();
+
+    service = module.get<CommonService>(CommonService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/nestjs_server/src/common/common.service.ts
+++ b/nestjs_server/src/common/common.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class CommonService {}

--- a/nestjs_server/src/common/entity/base.entity.ts
+++ b/nestjs_server/src/common/entity/base.entity.ts
@@ -1,0 +1,12 @@
+import {CreateDateColumn, PrimaryGeneratedColumn, UpdateDateColumn} from 'typeorm';
+
+export abstract class BaseModel {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/nestjs_server/src/posts/entities/posts.entity.ts
+++ b/nestjs_server/src/posts/entities/posts.entity.ts
@@ -1,11 +1,9 @@
-import {Column, Entity, ManyToOne, PrimaryGeneratedColumn} from 'typeorm';
+import {Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn, UpdateDateColumn} from 'typeorm';
 import {UsersModel} from '../../users/entities/users.entity';
+import {BaseModel} from '../../common/entity/base.entity';
 
 @Entity()
-export class PostsModel {
-    @PrimaryGeneratedColumn()
-    id: number;
-
+export class PostsModel extends BaseModel {
     /**
      * 1) UsersModel과 연동한다. Foreign key를 이용해서
      * 2) null이 될 수 없다.

--- a/nestjs_server/src/users/entities/users.entity.ts
+++ b/nestjs_server/src/users/entities/users.entity.ts
@@ -1,4 +1,4 @@
-import {Column, Entity, OneToMany, PrimaryGeneratedColumn} from 'typeorm';
+import {Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn} from 'typeorm';
 import {RolesEnum} from '../const/roles.const';
 import {PostModel} from '../../posts/posts.service';
 import {PostsModel} from '../../posts/entities/posts.entity';
@@ -49,5 +49,10 @@ export class UsersModel {
 
     @OneToMany(() => PostsModel, (post) => post.author)
     posts: PostModel[];
-}
 
+    @UpdateDateColumn()
+    updatedAt: Date;
+
+    @CreateDateColumn()
+    createdAt: Date;
+}

--- a/nestjs_server/src/users/entities/users.entity.ts
+++ b/nestjs_server/src/users/entities/users.entity.ts
@@ -2,6 +2,7 @@ import {Column, CreateDateColumn, Entity, OneToMany, PrimaryGeneratedColumn, Upd
 import {RolesEnum} from '../const/roles.const';
 import {PostModel} from '../../posts/posts.service';
 import {PostsModel} from '../../posts/entities/posts.entity';
+import {BaseModel} from '../../common/entity/base.entity';
 
 /**
  * id: number
@@ -16,10 +17,7 @@ import {PostsModel} from '../../posts/entities/posts.entity';
  */
 
 @Entity()
-export class UsersModel {
-    @PrimaryGeneratedColumn()
-    id: number;
-
+export class UsersModel extends BaseModel {
     /**
      * 1) 길이가 20을 넘지 않을 것
      * 2) 유일무이한 값이 될 것
@@ -49,10 +47,4 @@ export class UsersModel {
 
     @OneToMany(() => PostsModel, (post) => post.author)
     posts: PostModel[];
-
-    @UpdateDateColumn()
-    updatedAt: Date;
-
-    @CreateDateColumn()
-    createdAt: Date;
 }


### PR DESCRIPTION
## 🔥 관련이슈
close #26 

## 🔥 PR Point
- UpdatedAt과 CreatedAt을 자동으로 생성하는 방법
- BaseModel 적용하기

[책](https://product.kyobobook.co.kr/detail/S000001019679)에서 봤던 내용을 예상했는데 역시 예상대로였다. 엔티티들의 중복을 제거하기 위한 섹션이었다. 쉽게 적용할 수 있는 부분이라 느꼈다.