### PR TITLE
[코드팩토리] 섹션22. Pagination 기본기 - Cursor Pagination

### DIFF
--- a/conscious-practice/cf_sns/src/common/const/env.const.ts
+++ b/conscious-practice/cf_sns/src/common/const/env.const.ts
@@ -1,0 +1,2 @@
+export const PROTOCOL = 'http';
+export const HOST = 'localhost:3000';

--- a/conscious-practice/cf_sns/src/main.ts
+++ b/conscious-practice/cf_sns/src/main.ts
@@ -8,6 +8,10 @@ async function bootstrap() {
     new ValidationPipe({
       // 페이지네이션 구현 시 쿼리에 요청(예: 정렬방법)이 들어오지 않아도 기본값을 할당하기 위해 옵션 추가
       transform: true,
+      // 자료형 데코레이터를 기준으로 변환 할 수 있도록 옵션 추가 class-validation과 함께 사용
+      transformOptions: {
+        enableImplicitConversion: true, // 암묵적으로 형 변환
+      },
     }),
   );
   await app.listen(3000);

--- a/conscious-practice/cf_sns/src/main.ts
+++ b/conscious-practice/cf_sns/src/main.ts
@@ -4,7 +4,12 @@ import { ValidationPipe } from '@nestjs/common';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
-  app.useGlobalPipes(new ValidationPipe());
+  app.useGlobalPipes(
+    new ValidationPipe({
+      // 페이지네이션 구현 시 쿼리에 요청(예: 정렬방법)이 들어오지 않아도 기본값을 할당하기 위해 옵션 추가
+      transform: true,
+    }),
+  );
   await app.listen(3000);
 }
 

--- a/conscious-practice/cf_sns/src/posts/dto/paginate-post.dto.ts
+++ b/conscious-practice/cf_sns/src/posts/dto/paginate-post.dto.ts
@@ -1,0 +1,20 @@
+import { IsIn, IsNumber, IsOptional } from 'class-validator';
+
+/**
+ * where__id_more_than: 이전 마지막 데이터 ID
+ * order__createdAt: 작성된 시간을 기준으로 정렬
+ * take: 몇 개의 데이터를 응답으로 받을 지
+ */
+export class PaginatePostDto {
+  @IsOptional()
+  @IsNumber()
+  where__id_more_than?: number;
+
+  @IsIn(['ASC'])
+  @IsOptional()
+  order__createdAt? = 'ASC' as const;
+
+  @IsOptional()
+  @IsNumber()
+  take: number = 20;
+}

--- a/conscious-practice/cf_sns/src/posts/dto/paginate-post.dto.ts
+++ b/conscious-practice/cf_sns/src/posts/dto/paginate-post.dto.ts
@@ -8,11 +8,15 @@ import { IsIn, IsNumber, IsOptional } from 'class-validator';
 export class PaginatePostDto {
   @IsOptional()
   @IsNumber()
+  where__id_less_than?: number;
+
+  @IsOptional()
+  @IsNumber()
   where__id_more_than?: number;
 
-  @IsIn(['ASC'])
+  @IsIn(['ASC', 'DESC'])
   @IsOptional()
-  order__createdAt? = 'ASC' as const;
+  order__createdAt: 'ASC' | 'DESC' = 'ASC';
 
   @IsOptional()
   @IsNumber()

--- a/conscious-practice/cf_sns/src/posts/posts.controller.ts
+++ b/conscious-practice/cf_sns/src/posts/posts.controller.ts
@@ -7,22 +7,23 @@ import {
   ParseIntPipe,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
-import { PostsEntity } from './entities/posts.entity';
 import { AccessTokenGuard } from '../auth/guard/bearer-token.guard';
 import { User } from '../users/decorator/user.decorator';
+import { PaginatePostDto } from './dto/paginate-post.dto';
 
 @Controller('posts')
 export class PostsController {
   constructor(private readonly postsService: PostsService) {}
 
   @Get()
-  findAll(): Promise<PostsEntity[]> {
-    return this.postsService.findAll();
+  findAll(@Query() query: PaginatePostDto) {
+    return this.postsService.paginate(query);
   }
 
   @Get(':id')

--- a/conscious-practice/cf_sns/src/posts/posts.controller.ts
+++ b/conscious-practice/cf_sns/src/posts/posts.controller.ts
@@ -16,6 +16,7 @@ import { UpdatePostDto } from './dto/update-post.dto';
 import { AccessTokenGuard } from '../auth/guard/bearer-token.guard';
 import { User } from '../users/decorator/user.decorator';
 import { PaginatePostDto } from './dto/paginate-post.dto';
+import { UsersEntity } from '../users/entities/users.entity';
 
 @Controller('posts')
 export class PostsController {
@@ -29,6 +30,13 @@ export class PostsController {
   @Get(':id')
   findById(@Param('id', ParseIntPipe) id: number) {
     return this.postsService.findById(id);
+  }
+
+  @UseGuards(AccessTokenGuard)
+  @Post('random')
+  async generatePostList(@User() user: UsersEntity) {
+    await this.postsService.generatePostList(user.id);
+    return true;
   }
 
   @UseGuards(AccessTokenGuard)

--- a/conscious-practice/cf_sns/src/posts/posts.service.ts
+++ b/conscious-practice/cf_sns/src/posts/posts.service.ts
@@ -35,6 +35,18 @@ export class PostsService {
     return { data: postList };
   }
 
+  /**
+   * 페이지네이션을 테스트 하는 테스트 함수
+   */
+  async generatePostList(userId: number) {
+    for (let i = 0; i < 100; i++) {
+      await this.create(userId, {
+        title: `테스트 제목${i}`,
+        content: `테스트 내용${i}`,
+      });
+    }
+  }
+
   async findById(id: number) {
     const post = await this.postsRepository.findOne({
       where: {

--- a/conscious-practice/cf_sns/src/posts/posts.service.ts
+++ b/conscious-practice/cf_sns/src/posts/posts.service.ts
@@ -1,9 +1,10 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreatePostDto } from './dto/create-post.dto';
-import { Repository } from 'typeorm';
+import { MoreThan, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { PostsEntity } from './entities/posts.entity';
+import { PaginatePostDto } from './dto/paginate-post.dto';
 
 @Injectable()
 export class PostsService {
@@ -16,6 +17,22 @@ export class PostsService {
     return await this.postsRepository.find({
       relations: ['author'],
     });
+  }
+
+  /**
+   * 오름차순으로 정렬하는 페이지네이션
+   */
+  async paginate(pageRequest: PaginatePostDto) {
+    const postList = await this.postsRepository.find({
+      where: {
+        // ID 값이 정의되지 않았을 때 nullish 연산자를 사용해서 0으로 할당
+        id: MoreThan(pageRequest.where__id_more_than ?? 0),
+      },
+      order: { createdAt: pageRequest.order__createdAt },
+      take: pageRequest.take,
+    });
+
+    return { data: postList };
   }
 
   async findById(id: number) {

--- a/conscious-practice/cf_sns/src/posts/posts.service.ts
+++ b/conscious-practice/cf_sns/src/posts/posts.service.ts
@@ -1,10 +1,11 @@
 import { Injectable, NotFoundException } from '@nestjs/common';
 import { CreatePostDto } from './dto/create-post.dto';
-import { MoreThan, Repository } from 'typeorm';
+import { FindOptionsWhere, LessThan, MoreThan, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { UpdatePostDto } from './dto/update-post.dto';
 import { PostsEntity } from './entities/posts.entity';
 import { PaginatePostDto } from './dto/paginate-post.dto';
+import { HOST, PROTOCOL } from '../common/const/env.const';
 
 @Injectable()
 export class PostsService {
@@ -23,6 +24,13 @@ export class PostsService {
    * 오름차순으로 정렬하는 페이지네이션
    */
   async paginate(pageRequest: PaginatePostDto) {
+    const where: FindOptionsWhere<PostsEntity> = {};
+    if (pageRequest.where__id_less_than) {
+      where.id = LessThan(pageRequest.where__id_less_than);
+    } else if (pageRequest.where__id_more_than) {
+      where.id = MoreThan(pageRequest.where__id_more_than);
+    }
+
     const postList = await this.postsRepository.find({
       where: {
         // ID 값이 정의되지 않았을 때 nullish 연산자를 사용해서 0으로 할당
@@ -32,7 +40,41 @@ export class PostsService {
       take: pageRequest.take,
     });
 
-    return { data: postList };
+    const lastItem =
+      postList.length > 0 && postList.length === pageRequest.take
+        ? postList[postList.length - 1]
+        : null;
+
+    const nextURL = lastItem && new URL(`${PROTOCOL}://${HOST}/posts`);
+
+    if (nextURL) {
+      for (const key of Object.keys(pageRequest)) {
+        if (pageRequest[key]) {
+          if (key !== 'where__id_more_than' && key !== 'where__id_less_than') {
+            nextURL.searchParams.append(key, pageRequest[key]);
+          }
+        }
+      }
+
+      let key = null;
+
+      if (pageRequest.order__createdAt === 'ASC') {
+        key = 'where__id_more_than';
+      } else {
+        key = 'where__id_less_than';
+      }
+
+      nextURL.searchParams.append(key, lastItem.id.toString());
+    }
+
+    return {
+      data: postList,
+      cursor: {
+        after: lastItem?.id ?? null,
+      },
+      count: postList.length,
+      next: nextURL?.toString() ?? null,
+    };
   }
 
   /**


### PR DESCRIPTION
## 🔥 참고

- [TypeORM 페이지네이션 조회 쿼리옵션](https://orkhan.gitbook.io/typeorm/docs/find-options)

## 🔥 PR Point

- 데이터를 페이지별로 나누어 가져오는 방법이다. 
  - 모든 데이터를 가져오는 것은 제한적이다. 리소스의 낭비가 크다.
  - page pagination, cursor pagination
- take: limit 몇 개를 가져올 것인가
- skip: offset 가져올 데이터의 초기 위치(검색 시작 행)